### PR TITLE
Bumps logstash version and adds defaults for ubuntu.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ logstash_python_utils:
  - { package: "python-pycurl" }
  - { package: "python-apt" }
 
-logstash_version: "2.1"
+logstash_version: "2.2"
 
 logstash_apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_version }}/debian stable main"
 logstash_repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"

--- a/tasks/logstash_installation_Debian.yml
+++ b/tasks/logstash_installation_Debian.yml
@@ -1,28 +1,27 @@
 ---
 - name: Enable Logstash Repository
-  apt_repository: repo="{{ logstash_apt_repo }}" 
+  apt_repository: repo="{{ logstash_apt_repo }}"
                   state=present
   tags: logstash_repo
 
 - name: Add Logstash Repo Key
-  apt_key: url="{{ logstash_repo_key }}" 
+  apt_key: url="{{ logstash_repo_key }}"
            state=present
   tags: logstash_repo
 
 - name: Install Logstash
   apt: pkg=logstash
-       update_cache=yes 
+       update_cache=yes
        state=latest
   tags: logstash_install
 
-- name: Configure default settings for Logstash (Debian only. Upstart on Ubuntu won't be touched)
+- name: Configure default settings for Logstash
   template: src=defaults.conf.j2
             dest={{ defaults_Debian }}
             owner=root
             group=root
             mode=0644
             backup=yes
-  when: ansible_distribution == "Debian"
   notify:
    - restart logstash
   tags:


### PR DESCRIPTION
Is there a reason for not add /etc/default/logstash in ubuntu ?