### PR TITLE
bump to version 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Example Playbooks
     - role: valentinogagliardi.logstash-role
 
       logstash_defaults: |
-        LS_USER=root
         LS_HEAP_SIZE="256m"
-        LS_OPTS="--auto-reload --reload-interval 2"
+        LS_OPTS="-r --config.reload.interval 2"
 
       logstash_patterns: |
         TIMESTAMP_FOO %{MONTHDAY}-%{MONTH}-%{YEAR}-%{HOUR}:%{MINUTE}:%{SECOND}
@@ -70,10 +69,13 @@ logstash_apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_v
 logstash_repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
 logstash_yum_repo_dest: "/etc/yum.repos.d/logstash.repo"
 
+logstash_home: "/usr/share/logstash"
+logstash_settings: "/etc/logstash"
+
 logstash_conf_dir: "/etc/logstash/conf.d/"
 logstash_patterns_file: "/etc/logstash/patterns/extra"
 
-logstash_defaults: "LS_USER=logstash"
+logstash_defaults: "LS_HEAP_SIZE="512m""
 
 defaults_RedHat: "/etc/sysconfig/logstash"
 defaults_Debian: "/etc/default/logstash"
@@ -88,4 +90,3 @@ Author Information
 ------------------
 
 Valentino Gagliardi - valentino.g@servermanaged.it
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,19 +5,32 @@ logstash_python_utils:
  - { package: "python-pycurl" }
  - { package: "python-apt" }
 
-logstash_version: "2.4"
+logstash_version: "5.0"
 
 logstash_apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_version }}/debian stable main"
 logstash_repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
 logstash_yum_repo_dest: "/etc/yum.repos.d/logstash.repo"
 
+logstash_home: "/usr/share/logstash"
+logstash_settings: "/etc/logstash"
+
 logstash_conf_dir: "/etc/logstash/conf.d/"
 logstash_patterns_file: "/etc/logstash/patterns/extra"
 
-logstash_defaults: "LS_USER=logstash"
-
 defaults_RedHat: "/etc/sysconfig/logstash"
 defaults_Debian: "/etc/default/logstash"
+
+# following options are required so logstash can be setup correctly as a 'service'
+logstash_startup_options_service_name: "logstash"
+logstash_startup_options_service_description: "logstash"
+logstash_startup_options_user: "logstash"
+logstash_startup_options_group: "logstash"
+logstash_startup_options_home: "{{ logstash_home }}"
+logstash_startup_options_settings_dir: "{{ logstash_settings }}"
+logstash_startup_options_opts: ""
+logstash_startup_options_nice: 19
+logstash_startup_options_open_files: 16384
+logstash_startup_options_prestart: ""
 
 logstash_plugins:
   - { plugin_name: "logstash-output-null" }

--- a/tasks/logstash_configuration.yml
+++ b/tasks/logstash_configuration.yml
@@ -19,7 +19,7 @@
             owner=root
             group=root
             mode=0644
-            validate='/opt/logstash/bin/logstash -tf %s'
+            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'
 
 - name: Validate and copy Logstash Filter Configuration
   template: src=filters.conf.j2
@@ -27,7 +27,7 @@
             owner=root
             group=root
             mode=0644
-            validate='/opt/logstash/bin/logstash -tf %s'
+            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'
 
 - name: Validate and copy Logstash Output Configuration
   template: src=output.conf.j2
@@ -35,4 +35,4 @@
             owner=root
             group=root
             mode=0644
-            validate='/opt/logstash/bin/logstash -tf %s'
+            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'

--- a/tasks/logstash_installation_Debian.yml
+++ b/tasks/logstash_installation_Debian.yml
@@ -2,7 +2,7 @@
 - name: Check whether an update for Logstash is available (Deb)
   shell: 'apt-get update && apt-get upgrade --dry-run'
   register: update_result
-  changed_when: "'logstash' in update_result.stdout"
+  changed_when: "'logstash ' in update_result.stdout" # space character after logstash is important to distinguish available update line from another message.
 
 - name: Stop Logstash before upgrading
   service: name=logstash
@@ -21,8 +21,9 @@
 - name: Install Logstash
   apt: pkg=logstash
        update_cache=yes
+       allow_unauthenticated=yes
        state=latest
-  notify: 
+  notify:
    - start logstash
 
 - name: Configure default settings for Logstash

--- a/tasks/logstash_installation_RedHat.yml
+++ b/tasks/logstash_installation_RedHat.yml
@@ -12,18 +12,18 @@
   when: update_result.changed
 
 - name: Enable Logstash repository
-  template: src=logstash_repo.j2 
+  template: src=logstash_repo.j2
             dest={{ logstash_yum_repo_dest }}
 
 - name: Add Logstash Repo Key
-  rpm_key: key="{{ logstash_repo_key }}" 
+  rpm_key: key="{{ logstash_repo_key }}"
            state=present
 
 - name: Install Logstash
   yum: name=logstash
        state=latest
        update_cache=yes
-  notify: 
+  notify:
    - start logstash
 
 - name: Configure default settings for Logstash

--- a/tasks/logstash_plugins.yml
+++ b/tasks/logstash_plugins.yml
@@ -1,4 +1,4 @@
 
 - name: Install Logstash Plugins
-  command: /opt/logstash/bin/logstash-plugin install {{ item.plugin_name }}
+  command: '{{logstash_home}}/bin/logstash-plugin install {{ item.plugin_name }}'
   with_items: "{{ logstash_plugins }}"

--- a/tasks/logstash_system_install.yml
+++ b/tasks/logstash_system_install.yml
@@ -1,0 +1,27 @@
+
+
+- name: Update startup.options file
+  # because backup option on lineinfile below would create a new backup file each time
+  copy: src="{{ logstash_settings }}/startup.options" dest="{{ logstash_settings }}/startup.options.{{ansible_date_time.iso8601}}" remote_src=yes
+- lineinfile: dest="{{ logstash_settings }}/startup.options" regexp="^({{ item.key }}).*$" line="\1={{ item.value }}" backrefs=yes backup=no
+  with_items:
+    - { key: "SERVICE_NAME", value: "{{logstash_startup_options_service_name}}" }
+    - { key: "SERVICE_DESCRIPTION", value: "{{logstash_startup_options_service_description}}" }
+    - { key: "LS_USER", value: "{{logstash_startup_options_user}}" }
+    - { key: "LS_GROUP", value: "{{logstash_startup_options_group}}" }
+    - { key: "LS_HOME", value: "{{logstash_startup_options_home}}" }
+    - { key: "LS_SETTINGS_DIR", value: "{{logstash_startup_options_settings_dir}}" }
+    - { key: "LS_OPTS", value: "{{logstash_startup_options_opts}}" }
+    - { key: "LS_NICE", value: "{{logstash_startup_options_nice}}" }
+    - { key: "LS_OPEN_FILES", value: "{{logstash_startup_options_open_files}}" }
+
+- blockinfile: dest="{{ logstash_settings }}/startup.options" content="{{ logstash_startup_options_prestart }}" insertbefore="^## EOM" backup=no
+  when: "logstash_startup_options_prestart != ''"
+
+- replace: dest="{{ logstash_settings }}/startup.options" regexp="^## (.*)$" replace="\1" backup=no
+  when: "logstash_startup_options_prestart != ''"
+
+- name: Setup logstash service
+  shell: '{{ logstash_home }}/bin/system-install {{ logstash_settings }}/startup.options'
+  notify:
+   - restart logstash

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,8 @@
   when: ansible_os_family == "RedHat"
   tags: [logstash, logstash-install, logstash-install-redhat]
 
+- include: logstash_system_install.yml
+
 - include: logstash_plugins.yml
 
 - include: logstash_configuration.yml

--- a/templates/defaults.conf.j2
+++ b/templates/defaults.conf.j2
@@ -1,3 +1,5 @@
+LS_HOME="{{ logstash_home }}"
+LS_SETTINGS_DIR="{{ logstash_settings }}"
 {% if logstash_defaults is defined %}
 {{ logstash_defaults }}
 {% endif %}

--- a/test.yml
+++ b/test.yml
@@ -3,10 +3,9 @@
   roles:
     - role: logstash-role
       logstash_defaults: |
-        LS_USER=root
         LS_HEAP_SIZE="256m"
-        LS_OPTS="--auto-reload --reload-interval 2"
-      
+        LS_OPTS="-r --config.reload.interval 2"
+
       logstash_inputs: |
         file {
               path => "/var/log/auth.log"


### PR DESCRIPTION
I updated the role so it can install the latest version of Logstash (5.0 right now).

I tried to keep the way the developer can declare the configuration of the role.

However, in 5.0, there has been a big change related to how Logstash is installed as a service. IMHO, Logstash developers have created a big mess with environment variables, because some of them must be in *startup.options* file whereas other ones can still live in regular default environment file (aka /etc/default/logstash on Debian-like hosts). More details [here](https://www.elastic.co/guide/en/logstash/5.0/config-setting-files.html#_settings_files). Logstash packages (rpm/deb) do not even provide any default environment file anymore...

Because of the mess, the situation is really hard to explain clearly in the README.md. As a consequence, the developer has to know what he is doing and where he should set the environment variables.

Tested on both ubuntu and centos virtual machines.